### PR TITLE
fix(deployment): fail-safe-deploy script deploys to the gnosis address

### DIFF
--- a/scripts/fail-safe-deploy.ts
+++ b/scripts/fail-safe-deploy.ts
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
     .createSafeGuard(
       oneDayTimelock,
       safeGuardDescription,
-      process.env.METAMASK_ADDRESS,
+      process.env.SAFE_ADDRESS,
       [proposerRole, executerRole, cancelerRole, ],
       [
         process.env.METAMASK_ADDRESS,


### PR DESCRIPTION
I think the deploy scripts was deploying the safeguard to the metamask address, whereas it should have been deployed to the gnosis multisig.